### PR TITLE
feat: Add `center` direction & unified transitions for true responsive dialogs

### DIFF
--- a/apps/www/src/components/examples/responsive.tsx
+++ b/apps/www/src/components/examples/responsive.tsx
@@ -1,0 +1,43 @@
+import { Drawer } from "vaul-base"
+
+import { Button } from "@/components/button"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { cn } from "@/lib/utils"
+
+const ResponsiveDrawer = () => {
+  const isMobile = useIsMobile()
+  return (
+    <Drawer.Root direction={isMobile ? "bottom" : "center"}>
+      <Drawer.Trigger
+        render={(props) => <Button {...props}>Open Drawer</Button>}
+      />
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 bg-black/80" />
+        <Drawer.Content className={cn("bg-background text-foreground fixed inset-x-0 bottom-0 h-auto w-full max-w-xl rounded-lg border", isMobile && "max-w-full rounded-b-none")}>
+         {isMobile && <Drawer.Handle className="top-4" />}
+          <div className="flex flex-col space-y-4 p-6">
+            <h4 className="font-semibold">Welcome to the Drawer</h4>
+            <p>
+              This drawer adapts its direction based on your screen size.
+            </p>
+            <p>
+              We just change the direction prop dynamically using a custom hook. The transition between directions is 
+              handeled smoothly by the drawer component.
+            </p>
+
+
+            <pre className="rounded bg-muted p-4 text-sm overflow-x-auto">
+              <code>{`<Drawer.Root direction={isMobile ? "bottom" : "center"}>
+  ...
+</Drawer.Root>`}
+              </code>
+            </pre>
+            
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  )
+}
+
+export default ResponsiveDrawer

--- a/apps/www/src/components/examples/responsive.tsx
+++ b/apps/www/src/components/examples/responsive.tsx
@@ -2,7 +2,6 @@ import { Drawer } from "vaul-base"
 
 import { Button } from "@/components/button"
 import { useIsMobile } from "@/hooks/use-mobile"
-import { cn } from "@/lib/utils"
 
 const ResponsiveDrawer = () => {
   const isMobile = useIsMobile()
@@ -13,8 +12,18 @@ const ResponsiveDrawer = () => {
       />
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 bg-black/80" />
-        <Drawer.Content className={cn("bg-background text-foreground fixed inset-x-0 bottom-0 h-auto w-full max-w-xl rounded-lg border", isMobile && "max-w-full rounded-b-none")}>
-         {isMobile && <Drawer.Handle className="top-4" />}
+        <Drawer.Content className="bg-background text-foreground fixed inset-x-0 bottom-0 h-auto w-full border group
+
+        data-[vaul-drawer-direction=center]:max-w-xl data-[vaul-drawer-direction=center]:rounded-lg
+        data-[vaul-drawer-direction=bottom]:max-w-full data-[vaul-drawer-direction=bottom]:rounded-b-none
+        data-[vaul-drawer-direction=top]:max-w-full data-[vaul-drawer-direction=top]:rounded-b-none
+        data-[vaul-drawer-direction=left]:max-w-64 data-[vaul-drawer-direction=left]:w-2/3 data-[vaul-drawer-direction=left]:rounded-lg data-[vaul-drawer-direction=left]:h-full
+        data-[vaul-drawer-direction=right]:max-w-64 data-[vaul-drawer-direction=right]:w-2/3 data-[vaul-drawer-direction=right]:rounded-lg data-[vaul-drawer-direction=right]:h-full
+        ">
+          <div className="hidden group-data-[vaul-drawer-direction=bottom]:block">
+            <Drawer.Handle className="top-3" />
+          </div>
+
           <div className="flex flex-col space-y-4 p-6">
             <h4 className="font-semibold">Welcome to the Drawer</h4>
             <p>
@@ -23,7 +32,7 @@ const ResponsiveDrawer = () => {
             <p>
               We just change the direction prop dynamically using a custom hook. The transition between directions is 
               handeled smoothly by the drawer component.
-            </p>
+            </p> 
 
 
             <pre className="rounded bg-muted p-4 text-sm overflow-x-auto">
@@ -32,7 +41,10 @@ const ResponsiveDrawer = () => {
 </Drawer.Root>`}
               </code>
             </pre>
-            
+          </div>
+          
+          <div className="hidden group-data-[vaul-drawer-direction=top]:block">
+            <Drawer.Handle className="-top-3" />
           </div>
         </Drawer.Content>
       </Drawer.Portal>

--- a/apps/www/src/components/examples/responsive.tsx
+++ b/apps/www/src/components/examples/responsive.tsx
@@ -12,13 +12,13 @@ const ResponsiveDrawer = () => {
       />
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 bg-black/80" />
-        <Drawer.Content className="bg-background text-foreground fixed inset-x-0 bottom-0 h-auto w-full border group
+        <Drawer.Content className="bg-background text-foreground fixed inset-x-0 bottom-0 h-auto w-full border group rounded-lg
 
-        data-[vaul-drawer-direction=center]:max-w-xl data-[vaul-drawer-direction=center]:rounded-lg
+        data-[vaul-drawer-direction=center]:max-w-xl
         data-[vaul-drawer-direction=bottom]:max-w-full data-[vaul-drawer-direction=bottom]:rounded-b-none
-        data-[vaul-drawer-direction=top]:max-w-full data-[vaul-drawer-direction=top]:rounded-b-none
-        data-[vaul-drawer-direction=left]:max-w-64 data-[vaul-drawer-direction=left]:w-2/3 data-[vaul-drawer-direction=left]:rounded-lg data-[vaul-drawer-direction=left]:h-full
-        data-[vaul-drawer-direction=right]:max-w-64 data-[vaul-drawer-direction=right]:w-2/3 data-[vaul-drawer-direction=right]:rounded-lg data-[vaul-drawer-direction=right]:h-full
+        data-[vaul-drawer-direction=top]:max-w-full data-[vaul-drawer-direction=top]:rounded-t-none
+        data-[vaul-drawer-direction=left]:max-w-64 data-[vaul-drawer-direction=left]:w-2/3 data-[vaul-drawer-direction=left]:rounded-l-none data-[vaul-drawer-direction=left]:h-full
+        data-[vaul-drawer-direction=right]:max-w-64 data-[vaul-drawer-direction=right]:w-2/3 data-[vaul-drawer-direction=right]:rounded-r-none data-[vaul-drawer-direction=right]:h-full
         ">
           <div className="hidden group-data-[vaul-drawer-direction=bottom]:block">
             <Drawer.Handle className="top-3" />

--- a/apps/www/src/constants/examples.tsx
+++ b/apps/www/src/constants/examples.tsx
@@ -2,6 +2,7 @@ import BasicDrawer from "@/components/examples/basic"
 import DirectionsDrawer from "@/components/examples/directions"
 import NestedDrawer from "@/components/examples/nested"
 import NonDismissableDrawer from "@/components/examples/non-dismissable"
+import ResponsiveDrawer from "@/components/examples/responsive"
 import ScaledBackgroundDrawer from "@/components/examples/scaled-background"
 import { ScrollableDrawer } from "@/components/examples/scrollable"
 import SnapPointsDrawer from "@/components/examples/snap-points"
@@ -23,6 +24,11 @@ export const EXAMPLES = {
     name: "Directions",
     description: "Drawers can be opened from different sides of the screen.",
     render: () => <DirectionsDrawer />,
+  },
+    responsive: {
+    name: "Responsive",
+    description: "Changing drawer direction based on screen size.",
+    render: () => <ResponsiveDrawer />,
   },
   "scaled-background": {
     name: "Scaled Background",

--- a/apps/www/src/hooks/use-mobile.ts
+++ b/apps/www/src/hooks/use-mobile.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
+    undefined
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener('change', onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return !!isMobile;
+}

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -115,7 +115,7 @@ export type DialogProps = {
    * Direction of the drawer. Can be `top` or `bottom`, `left`, `right`.
    * @default 'bottom'
    */
-  direction?: "top" | "bottom" | "left" | "right"
+  direction?: "top" | "bottom" | "left" | "right" | "center"
   /**
    * Opened by default, skips initial enter animation. Still reacts to `open` state changes
    * @default false
@@ -287,6 +287,7 @@ export function Root({
   }
 
   function onPress(event: React.PointerEvent<HTMLDivElement>) {
+    if (direction === "center") return
     if (!dismissible && !snapPoints) return
     if (drawerRef.current && !drawerRef.current.contains(event.target as Node))
       return
@@ -466,10 +467,12 @@ export function Root({
 
         const translateValue =
           Math.min(dampenedDraggedDistance * -1, 0) * directionMultiplier
+
+        const x = isVertical(direction) ? "50%" : `${translateValue}px`
+        const y = isVertical(direction) ? `${translateValue}px` : "50%"
+
         set(drawerRef.current, {
-          transform: isVertical(direction)
-            ? `translate3d(0, ${translateValue}px, 0)`
-            : `translate3d(${translateValue}px, 0, 0)`,
+          transform: `translate3d(${x}, ${y}, 0)`,
         })
         return
       }
@@ -518,10 +521,11 @@ export function Root({
       if (!snapPoints) {
         const translateValue = absDraggedDistance * directionMultiplier
 
+        const x = isVertical(direction) ? "50%" : `${translateValue}px`
+        const y = isVertical(direction) ? `${translateValue}px` : "50%"
+
         set(drawerRef.current, {
-          transform: isVertical(direction)
-            ? `translate3d(0, ${translateValue}px, 0)`
-            : `translate3d(${translateValue}px, 0, 0)`,
+          transform: `translate3d(${x}, ${y}, 0)`,
         })
       }
     }
@@ -626,8 +630,11 @@ export function Root({
     const wrapper = document.querySelector("[data-vaul-drawer-wrapper]")
     const currentSwipeAmount = getTranslate(drawerRef.current, direction)
 
+    const x = isVertical(direction) ? "50%" : "0"
+    const y = isVertical(direction) ? "0" : "50%"
+
     set(drawerRef.current, {
-      transform: "translate3d(0, 0, 0)",
+      transform: `translate3d(${x}, ${y}, 0)`,
       transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(",")})`,
     })
 
@@ -789,11 +796,12 @@ export function Root({
       window.clearTimeout(nestedOpenChangeTimer.current)
     }
 
+    const x = isVertical(direction) ? "50%" : `${initialTranslate}px`
+    const y = isVertical(direction) ? `${initialTranslate}px` : "50%"
+
     set(drawerRef.current, {
       transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(",")})`,
-      transform: isVertical(direction)
-        ? `scale(${scale}) translate3d(0, ${initialTranslate}px, 0)`
-        : `scale(${scale}) translate3d(${initialTranslate}px, 0, 0)`,
+      transform: `scale(${scale}) translate3d(${x}, ${y}, 0)`,
     })
 
     if (!o && drawerRef.current) {
@@ -802,11 +810,13 @@ export function Root({
           drawerRef.current as HTMLElement,
           direction
         )
+
+        const x = isVertical(direction) ? "50%" : `${translateValue}px`
+        const y = isVertical(direction) ? `${translateValue}px` : "50%"
+
         set(drawerRef.current, {
           transition: "none",
-          transform: isVertical(direction)
-            ? `translate3d(0, ${translateValue}px, 0)`
-            : `translate3d(${translateValue}px, 0, 0)`,
+          transform: `translate3d(${x}, ${y}, 0)`,
         })
       }, 500)
     }
@@ -816,6 +826,7 @@ export function Root({
     _event: React.PointerEvent<HTMLDivElement>,
     percentageDragged: number
   ) {
+    if (direction === "center") return
     if (percentageDragged < 0) return
 
     const initialScale =
@@ -824,10 +835,11 @@ export function Root({
     const newTranslate =
       -NESTED_DISPLACEMENT + percentageDragged * NESTED_DISPLACEMENT
 
+    const x = isVertical(direction) ? "50%" : `${newTranslate}px`
+    const y = isVertical(direction) ? `${newTranslate}px` : "50%"
+
     set(drawerRef.current, {
-      transform: isVertical(direction)
-        ? `scale(${newScale}) translate3d(0, ${newTranslate}px, 0)`
-        : `scale(${newScale}) translate3d(${newTranslate}px, 0, 0)`,
+      transform: `scale(${newScale}) translate3d(${x}, ${y}, 0)`,
       transition: "none",
     })
   }
@@ -836,16 +848,18 @@ export function Root({
     _event: React.PointerEvent<HTMLDivElement>,
     o: boolean
   ) {
+    if (direction === "center") return
     const dim = isVertical(direction) ? window.innerHeight : window.innerWidth
     const scale = o ? (dim - NESTED_DISPLACEMENT) / dim : 1
     const translate = o ? -NESTED_DISPLACEMENT : 0
 
     if (o) {
+      const x = isVertical(direction) ? "50%" : `${translate}px`
+      const y = isVertical(direction) ? `${translate}px` : "50%"
+
       set(drawerRef.current, {
         transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(",")})`,
-        transform: isVertical(direction)
-          ? `scale(${scale}) translate3d(0, ${translate}px, 0)`
-          : `scale(${scale}) translate3d(${translate}px, 0, 0)`,
+        transform: `scale(${scale}) translate3d(${x}, ${y}, 0)`,
       })
     }
   }
@@ -858,6 +872,13 @@ export function Root({
       })
     }
   }, [modal])
+
+    React.useLayoutEffect(() => {
+    if (drawerRef.current) {
+      drawerRef.current.style.removeProperty("transform")
+      drawerRef.current.style.removeProperty("transition")
+    }
+  }, [direction])
 
   return (
     <Dialog.Root
@@ -984,6 +1005,21 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
     React.useRef<React.PointerEvent<HTMLDivElement> | null>(null)
   const wasBeyondThePointRef = React.useRef(false)
   const hasSnapPoints = snapPoints && snapPoints.length > 0
+  const prevDirectionRef = React.useRef(direction)
+  const wasOpenRef = React.useRef(isOpen)
+  const isMorphing = React.useRef(false)
+
+  if (isOpen && wasOpenRef.current && prevDirectionRef.current !== direction) {
+    isMorphing.current = true
+  } else if (!isOpen) {
+    isMorphing.current = false
+  }
+
+  React.useEffect(() => {
+    prevDirectionRef.current = direction
+    wasOpenRef.current = isOpen
+  })
+
   useScaleBackground()
 
   const isDeltaInDirection = (
@@ -1032,6 +1068,7 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
     <Dialog.Popup
       data-vaul-drawer-direction={direction}
       data-vaul-drawer=""
+      data-vaul-drawer-morphing={isMorphing.current ? "true" : "false"}
       data-vaul-delayed-snap-points={delayedSnapPoints ? "true" : "false"}
       data-vaul-snap-points={isOpen && hasSnapPoints ? "true" : "false"}
       data-vaul-custom-container={container ? "true" : "false"}

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -13,6 +13,7 @@ import { useSnapPoints } from "@/hooks/use-snap-points"
 import { isIOS, isMobileFirefox } from "@/utils/browser"
 import {
   dampenValue,
+  getTransform,
   getTranslate,
   isVertical,
   reset,
@@ -333,7 +334,11 @@ export function Root({
       return false
     }
 
-    if (direction === "right" || direction === "left") {
+    if (
+      direction === "right" ||
+      direction === "left" ||
+      direction === "top"
+    ) {
       return true
     }
 
@@ -477,7 +482,7 @@ export function Root({
         const y = isVertical(direction) ? transformValue : "50%"
 
         set(drawerRef.current, {
-          transform: `translate3d(${x}, ${y}, 0)`,
+          transform: getTransform(direction, translateValue),
         })
         return
       }
@@ -535,7 +540,7 @@ export function Root({
         const y = isVertical(direction) ? transformValue : "50%"
 
         set(drawerRef.current, {
-          transform: `translate3d(${x}, ${y}, 0)`,
+          transform: getTransform(direction, translateValue),
         })
       }
     }
@@ -815,27 +820,19 @@ export function Root({
       window.clearTimeout(nestedOpenChangeTimer.current)
     }
 
-    const x = isVertical(direction) ? "50%" : `${initialTranslate}px`
-    const y = isVertical(direction) ? `${initialTranslate}px` : "50%"
-
     set(drawerRef.current, {
       transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(",")})`,
-      transform: `scale(${scale}) translate3d(${x}, ${y}, 0)`,
+      transform: `${getTransform(direction, initialTranslate)} scale(${scale})`,
     })
 
     if (!o && drawerRef.current) {
       nestedOpenChangeTimer.current = setTimeout(() => {
-        const translateValue = getTranslate(
-          drawerRef.current as HTMLElement,
-          direction
-        )
-
-        const x = isVertical(direction) ? "50%" : `${translateValue}px`
-        const y = isVertical(direction) ? `${translateValue}px` : "50%"
+        const translateValue =
+          getTranslate(drawerRef.current as HTMLElement, direction) || 0
 
         set(drawerRef.current, {
           transition: "none",
-          transform: `translate3d(${x}, ${y}, 0)`,
+          transform: getTransform(direction, translateValue),
         })
       }, 500)
     }
@@ -854,11 +851,8 @@ export function Root({
     const newTranslate =
       -NESTED_DISPLACEMENT + percentageDragged * NESTED_DISPLACEMENT
 
-    const x = isVertical(direction) ? "50%" : `${newTranslate}px`
-    const y = isVertical(direction) ? `${newTranslate}px` : "50%"
-
     set(drawerRef.current, {
-      transform: `scale(${newScale}) translate3d(${x}, ${y}, 0)`,
+      transform: `${getTransform(direction, newTranslate)} scale(${newScale})`,
       transition: "none",
     })
   }
@@ -873,12 +867,9 @@ export function Root({
     const translate = o ? -NESTED_DISPLACEMENT : 0
 
     if (o) {
-      const x = isVertical(direction) ? "50%" : `${translate}px`
-      const y = isVertical(direction) ? `${translate}px` : "50%"
-
       set(drawerRef.current, {
         transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(",")})`,
-        transform: `scale(${scale}) translate3d(${x}, ${y}, 0)`,
+        transform: `${getTransform(direction, translate)} scale(${scale})`,
       })
     }
   }
@@ -1088,8 +1079,10 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
       data-vaul-drawer-direction={direction}
       data-vaul-drawer=""
       data-vaul-drawer-morphing={isMorphing.current ? "true" : "false"}
-      data-vaul-delayed-snap-points={delayedSnapPoints ? "true" : "false"}
-      data-vaul-snap-points={isOpen && hasSnapPoints ? "true" : "false"}
+      data-vaul-delayed-snap-points={
+        isOpen && delayedSnapPoints ? "true" : "false"
+      }
+      data-vaul-snap-points={hasSnapPoints ? "true" : "false"}
       data-vaul-custom-container={container ? "true" : "false"}
       data-vaul-animate={shouldAnimate?.current ? "true" : "false"}
       {...rest}

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -468,8 +468,13 @@ export function Root({
         const translateValue =
           Math.min(dampenedDraggedDistance * -1, 0) * directionMultiplier
 
-        const x = isVertical(direction) ? "50%" : `${translateValue}px`
-        const y = isVertical(direction) ? `${translateValue}px` : "50%"
+        const transformValue =
+          direction === "left" || direction === "top"
+            ? `calc(100% + ${translateValue}px)`
+            : `${translateValue}px`
+
+        const x = isVertical(direction) ? "50%" : transformValue
+        const y = isVertical(direction) ? transformValue : "50%"
 
         set(drawerRef.current, {
           transform: `translate3d(${x}, ${y}, 0)`,
@@ -521,8 +526,13 @@ export function Root({
       if (!snapPoints) {
         const translateValue = absDraggedDistance * directionMultiplier
 
-        const x = isVertical(direction) ? "50%" : `${translateValue}px`
-        const y = isVertical(direction) ? `${translateValue}px` : "50%"
+        const transformValue =
+          direction === "left" || direction === "top"
+            ? `calc(100% + ${translateValue}px)`
+            : `${translateValue}px`
+
+        const x = isVertical(direction) ? "50%" : transformValue
+        const y = isVertical(direction) ? transformValue : "50%"
 
         set(drawerRef.current, {
           transform: `translate3d(${x}, ${y}, 0)`,
@@ -630,8 +640,11 @@ export function Root({
     const wrapper = document.querySelector("[data-vaul-drawer-wrapper]")
     const currentSwipeAmount = getTranslate(drawerRef.current, direction)
 
-    const x = isVertical(direction) ? "50%" : "0"
-    const y = isVertical(direction) ? "0" : "50%"
+    const transformValue =
+      direction === "left" || direction === "top" ? "100%" : "0px"
+
+    const x = isVertical(direction) ? "50%" : transformValue
+    const y = isVertical(direction) ? transformValue : "50%"
 
     set(drawerRef.current, {
       transform: `translate3d(${x}, ${y}, 0)`,
@@ -756,8 +769,14 @@ export function Root({
     )
 
     const isHorizontalSwipe = direction === "left" || direction === "right"
+    const swipeToClose =
+      direction === "left" || direction === "top"
+        ? (isHorizontalSwipe ? visibleDrawerWidth : visibleDrawerHeight) -
+          swipeAmount
+        : swipeAmount
+
     if (
-      Math.abs(swipeAmount) >=
+      Math.abs(swipeToClose) >=
       (isHorizontalSwipe ? visibleDrawerWidth : visibleDrawerHeight) *
         closeThreshold
     ) {

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -18,6 +18,10 @@
   margin-right: auto;
 }
 
+[data-vaul-drawer][data-vaul-snap-points="true"] {
+  --x-transform: 0;
+}
+
 [data-vaul-drawer][data-vaul-drawer-morphing="true"] {
   animation: none !important;
 }
@@ -26,10 +30,10 @@
   transform: translate3d(50%, 0, 0);
   animation-name: slideFromBottom;
 }
+
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="bottom"]:not(
     [data-open]
   ) {
-  transform: translate3d(50%, 100%, 0);
   animation-name: slideToBottom;
 }
 
@@ -37,10 +41,10 @@
   transform: translate3d(50%, 100%, 0);
   animation-name: slideFromTop;
 }
+
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="top"]:not(
     [data-open]
   ) {
-  transform: translate3d(50%, 0, 0);
   animation-name: slideToTop;
 }
 
@@ -51,7 +55,6 @@
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="left"]:not(
     [data-open]
   ) {
-  transform: translate3d(0, 50%, 0);
   animation-name: slideToLeft;
 }
 
@@ -59,11 +62,41 @@
   transform: translate3d(0, 50%, 0);
   animation-name: slideFromRight;
 }
+
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="right"]:not(
     [data-open]
   ) {
-  transform: translate3d(100%, 50%, 0);
   animation-name: slideToRight;
+}
+
+[data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="bottom"]:not(
+    [data-open]
+  ) {
+  animation-name: slideToBottom;
+}
+
+[data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="top"]:not(
+    [data-open]
+  ) {
+  animation-name: slideToTop;
+}
+
+[data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="left"]:not(
+    [data-open]
+  ) {
+  animation-name: slideToLeft;
+}
+
+[data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="right"]:not(
+    [data-open]
+  ) {
+  animation-name: slideToRight;
+}
+
+[data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="bottom"],
+[data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="top"] {
+  right: 0;
+  left: 0;
 }
 
 [data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="bottom"] {
@@ -74,37 +107,50 @@
   transform: translate3d(0, calc(var(--initial-transform, 100%) * -1), 0);
 }
 
+[data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="left"],
+[data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="right"] {
+  top: 0;
+  bottom: 0;
+}
+
 [data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="left"] {
   transform: translate3d(calc(var(--initial-transform, 100%) * -1), 0, 0);
+  left: 0;
+  right: auto;
 }
 
 [data-vaul-drawer][data-vaul-snap-points="true"][data-vaul-drawer-direction="right"] {
   transform: translate3d(var(--initial-transform, 100%), 0, 0);
 }
 
-[data-vaul-drawer][data-vaul-delayed-snap-points="true"][data-vaul-drawer-direction="top"] {
-  transform: translate3d(0, var(--snap-point-height, 0), 0);
-}
-
+[data-vaul-drawer][data-vaul-delayed-snap-points="true"][data-vaul-drawer-direction="top"],
 [data-vaul-drawer][data-vaul-delayed-snap-points="true"][data-vaul-drawer-direction="bottom"] {
   transform: translate3d(0, var(--snap-point-height, 0), 0);
+  right: 0;
+  left: 0;
+}
+
+[data-vaul-drawer][data-vaul-delayed-snap-points="true"][data-vaul-drawer-direction="left"],
+[data-vaul-drawer][data-vaul-delayed-snap-points="true"][data-vaul-drawer-direction="right"] {
+  transform: translate3d(var(--snap-point-height, 0), 0, 0);
+  top: 0;
+  bottom: 0;
 }
 
 [data-vaul-drawer][data-vaul-delayed-snap-points="true"][data-vaul-drawer-direction="left"] {
-  transform: translate3d(var(--snap-point-height, 0), 0, 0);
-}
-
-[data-vaul-drawer][data-vaul-delayed-snap-points="true"][data-vaul-drawer-direction="right"] {
-  transform: translate3d(var(--snap-point-height, 0), 0, 0);
+  left: 0;
+  right: auto;
 }
 
 [data-vaul-overlay][data-vaul-snap-points="false"] {
   animation-duration: 0.5s;
   animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
 }
+
 [data-vaul-overlay][data-vaul-snap-points="false"][data-open] {
   animation-name: fadeIn;
 }
+
 [data-vaul-overlay]:not([data-open]) {
   animation-name: fadeOut;
 }
@@ -114,12 +160,8 @@
 }
 
 [data-vaul-overlay][data-vaul-snap-points="true"] {
-  opacity: 0;
-  transition: opacity 0.5s cubic-bezier(0.32, 0.72, 0, 1);
-}
-
-[data-vaul-overlay][data-vaul-snap-points="true"] {
   opacity: 1;
+  transition: opacity 0.5s cubic-bezier(0.32, 0.72, 0, 1);
 }
 
 [data-vaul-drawer]:not([data-vaul-custom-container="true"])::after {
@@ -129,36 +171,38 @@
   background-color: inherit;
 }
 
-[data-vaul-drawer][data-vaul-drawer-direction="top"]::after {
-  top: initial;
-  bottom: 100%;
+[data-vaul-drawer][data-vaul-drawer-direction="top"]::after,
+[data-vaul-drawer][data-vaul-drawer-direction="bottom"]::after {
   left: 0;
   right: 0;
   height: 200%;
+}
+
+[data-vaul-drawer][data-vaul-drawer-direction="top"]::after {
+  top: initial;
+  bottom: 100%;
 }
 
 [data-vaul-drawer][data-vaul-drawer-direction="bottom"]::after {
   top: 100%;
   bottom: initial;
-  left: 0;
-  right: 0;
-  height: 200%;
+}
+
+[data-vaul-drawer][data-vaul-drawer-direction="left"]::after,
+[data-vaul-drawer][data-vaul-drawer-direction="right"]::after {
+  top: 0;
+  bottom: 0;
+  width: 200%;
 }
 
 [data-vaul-drawer][data-vaul-drawer-direction="left"]::after {
   left: initial;
   right: 100%;
-  top: 0;
-  bottom: 0;
-  width: 200%;
 }
 
 [data-vaul-drawer][data-vaul-drawer-direction="right"]::after {
   left: 100%;
   right: initial;
-  top: 0;
-  bottom: 0;
-  width: 200%;
 }
 
 [data-vaul-overlay][data-vaul-snap-points="true"]:not(
@@ -227,37 +271,35 @@
   }
 }
 
-@keyframes slideFromBottom {
-  from {
-    transform: translate3d(0, var(--initial-transform, 100%), 0);
-  }
-  to {
-    transform: translate3d(0, 0, 0);
-  }
-}
-
-@keyframes slideToBottom {
-  to {
-    transform: translate3d(0, var(--initial-transform, 100%), 0);
-  }
-}
-
 [data-vaul-drawer][data-vaul-drawer-direction="center"][data-open] {
   opacity: 1;
   transform: translate3d(50%, 50%, 0) scale(1);
   animation-name: none;
 }
+
 [data-vaul-drawer][data-vaul-drawer-direction="center"]:not([data-open]) {
   opacity: 0;
   transform: translate3d(50%, 50%, 0) scale(0.95);
   animation-name: none;
 }
 
-[data-vaul-drawer][data-vaul-drawer-direction="center"] {
-  bottom: 50%;
-  right: 50%;
+[data-vaul-drawer][data-vaul-drawer-direction="center"],
+[data-vaul-drawer][data-vaul-drawer-direction="bottom"],
+[data-vaul-drawer][data-vaul-drawer-direction="top"],
+[data-vaul-drawer][data-vaul-drawer-direction="left"],
+[data-vaul-drawer][data-vaul-drawer-direction="right"] {
   left: auto;
   top: auto;
+}
+
+[data-vaul-drawer][data-vaul-drawer-direction="center"],
+[data-vaul-drawer][data-vaul-drawer-direction="bottom"],
+[data-vaul-drawer][data-vaul-drawer-direction="top"] {
+  right: 50%;
+}
+
+[data-vaul-drawer][data-vaul-drawer-direction="center"] {
+  bottom: 50%;
   transform: translate3d(50%, 50%, 0) scale(0.95);
   position: fixed;
   touch-action: auto;
@@ -265,33 +307,23 @@
 
 [data-vaul-drawer][data-vaul-drawer-direction="bottom"] {
   bottom: 0;
-  right: 50%;
-  left: auto;
-  top: auto;
   transform: translate3d(50%, 0, 0);
 }
 
 [data-vaul-drawer][data-vaul-drawer-direction="top"] {
   bottom: 100%;
-  right: 50%;
-  left: auto;
-  top: auto;
   transform: translate3d(50%, 100%, 0);
 }
 
 [data-vaul-drawer][data-vaul-drawer-direction="left"] {
   bottom: 50%;
   right: 100%;
-  left: auto;
-  top: auto;
   transform: translate3d(100%, 50%, 0);
 }
 
 [data-vaul-drawer][data-vaul-drawer-direction="right"] {
   bottom: 50%;
   right: 0;
-  left: auto;
-  top: auto;
   transform: translate3d(0, 50%, 0);
 }
 
@@ -306,7 +338,7 @@
 
 @keyframes slideToTop {
   to {
-    transform: translate3d(50%, 0, 0);
+    transform: translate3d(var(--x-transform, 50%), 0, 0);
   }
 }
 
@@ -351,6 +383,6 @@
 
 @keyframes slideToBottom {
   to {
-    transform: translate3d(50%, 100%, 0);
+    transform: translate3d(var(--x-transform, 50%), 100%, 0);
   }
 }

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -1,44 +1,68 @@
 [data-vaul-drawer] {
   touch-action: none;
   will-change: transform;
-  transition: transform 0.5s cubic-bezier(0.32, 0.72, 0, 1);
+  transition:
+    transform 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    height 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    bottom 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    top 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    left 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    right 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    width 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    max-width 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    border-radius 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    opacity 0.5s cubic-bezier(0.32, 0.72, 0, 1);
   animation-duration: 0.5s;
   animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+[data-vaul-drawer][data-vaul-drawer-morphing="true"] {
+  animation: none !important;
 }
 
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="bottom"][data-open] {
+  transform: translate3d(50%, 0, 0);
   animation-name: slideFromBottom;
 }
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="bottom"]:not(
     [data-open]
   ) {
+  transform: translate3d(50%, 100%, 0);
   animation-name: slideToBottom;
 }
 
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="top"][data-open] {
+  transform: translate3d(50%, 100%, 0);
   animation-name: slideFromTop;
 }
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="top"]:not(
     [data-open]
   ) {
+  transform: translate3d(50%, 0, 0);
   animation-name: slideToTop;
 }
 
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="left"][data-open] {
+  transform: translate3d(100%, 50%, 0);
   animation-name: slideFromLeft;
 }
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="left"]:not(
     [data-open]
   ) {
+  transform: translate3d(0, 50%, 0);
   animation-name: slideToLeft;
 }
 
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="right"][data-open] {
+  transform: translate3d(0, 50%, 0);
   animation-name: slideFromRight;
 }
 [data-vaul-drawer][data-vaul-snap-points="false"][data-vaul-drawer-direction="right"]:not(
     [data-open]
   ) {
+  transform: translate3d(100%, 50%, 0);
   animation-name: slideToRight;
 }
 
@@ -218,47 +242,115 @@
   }
 }
 
+[data-vaul-drawer][data-vaul-drawer-direction="center"][data-open] {
+  opacity: 1;
+  transform: translate3d(50%, 50%, 0) scale(1);
+  animation-name: none;
+}
+[data-vaul-drawer][data-vaul-drawer-direction="center"]:not([data-open]) {
+  opacity: 0;
+  transform: translate3d(50%, 50%, 0) scale(0.95);
+  animation-name: none;
+}
+
+[data-vaul-drawer][data-vaul-drawer-direction="center"] {
+  bottom: 50%;
+  right: 50%;
+  left: auto;
+  top: auto;
+  transform: translate3d(50%, 50%, 0) scale(0.95);
+  position: fixed;
+  touch-action: auto;
+}
+
+[data-vaul-drawer][data-vaul-drawer-direction="bottom"] {
+  bottom: 0;
+  right: 50%;
+  left: auto;
+  top: auto;
+  transform: translate3d(50%, 0, 0);
+}
+
+[data-vaul-drawer][data-vaul-drawer-direction="top"] {
+  bottom: 100%;
+  right: 50%;
+  left: auto;
+  top: auto;
+  transform: translate3d(50%, 100%, 0);
+}
+
+[data-vaul-drawer][data-vaul-drawer-direction="left"] {
+  bottom: 50%;
+  right: 100%;
+  left: auto;
+  top: auto;
+  transform: translate3d(100%, 50%, 0);
+}
+
+[data-vaul-drawer][data-vaul-drawer-direction="right"] {
+  bottom: 50%;
+  right: 0;
+  left: auto;
+  top: auto;
+  transform: translate3d(0, 50%, 0);
+}
+
 @keyframes slideFromTop {
   from {
-    transform: translate3d(0, calc(var(--initial-transform, 100%) * -1), 0);
+    transform: translate3d(50%, 0, 0);
   }
   to {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(50%, 100%, 0);
   }
 }
 
 @keyframes slideToTop {
   to {
-    transform: translate3d(0, calc(var(--initial-transform, 100%) * -1), 0);
+    transform: translate3d(50%, 0, 0);
   }
 }
 
 @keyframes slideFromLeft {
   from {
-    transform: translate3d(calc(var(--initial-transform, 100%) * -1), 0, 0);
+    transform: translate3d(0, 50%, 0);
   }
   to {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(100%, 50%, 0);
   }
 }
 
 @keyframes slideToLeft {
   to {
-    transform: translate3d(calc(var(--initial-transform, 100%) * -1), 0, 0);
+    transform: translate3d(0, 50%, 0);
   }
 }
 
 @keyframes slideFromRight {
   from {
-    transform: translate3d(var(--initial-transform, 100%), 0, 0);
+    transform: translate3d(100%, 50%, 0);
   }
   to {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 50%, 0);
   }
 }
 
 @keyframes slideToRight {
   to {
-    transform: translate3d(var(--initial-transform, 100%), 0, 0);
+    transform: translate3d(100%, 50%, 0);
+  }
+}
+
+@keyframes slideFromBottom {
+  from {
+    transform: translate3d(50%, 100%, 0);
+  }
+  to {
+    transform: translate3d(50%, 0, 0);
+  }
+}
+
+@keyframes slideToBottom {
+  to {
+    transform: translate3d(50%, 100%, 0);
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,4 +1,4 @@
-export type DrawerDirection = "top" | "bottom" | "left" | "right"
+export type DrawerDirection = "top" | "bottom" | "left" | "right" | "center"
 export interface SnapPoint {
   fraction: number
   height: number

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -75,6 +75,19 @@ export const isVertical = (direction: DrawerDirection) => {
   }
 }
 
+export function getTransform(direction: DrawerDirection, translateValue: number) {
+  let x = isVertical(direction) ? "50%" : `${translateValue}px`
+  let y = isVertical(direction) ? `${translateValue}px` : "50%"
+
+  if (direction === "left") {
+    x = `calc(100% + ${translateValue}px)`
+  } else if (direction === "top") {
+    y = `calc(100% + ${translateValue}px)`
+  }
+
+  return `translate3d(${x}, ${y}, 0)`
+}
+
 export function getTranslate(
   element: HTMLElement,
   direction: DrawerDirection

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -68,6 +68,8 @@ export const isVertical = (direction: DrawerDirection) => {
     case "left":
     case "right":
       return false
+    case "center":
+      return true
     default:
       return direction satisfies never
   }


### PR DESCRIPTION
## Summary
Introducing a `center` direction and refactors the CSS/JS positioning logic to enable smooth, morphing transitions between all drawer directions (e.g., `bottom` <-> `center` ).

This allows developers to create **responsive dialogs** that maintain state (like form inputs) when resizing the window, offering a significantly better UX than the current standard practice.

## Problem
Currently, the standard approach for "Responsive Dialogs" (as seen in the [shadcn/ui examples](https://ui.shadcn.com/docs/components/drawer#responsive-dialog)) relies on conditional rendering:

```tsx
// Current standard approach
if (isDesktop) {
  return <Dialog open={open}><ProfileForm /></Dialog>
}
return <Drawer open={open}><ProfileForm /></Drawer>
```

**Issues with this approach:**
1.  **State Loss:** When resizing from mobile to desktop, the component tree changes. The `Drawer` unmounts and the `Dialog` mounts. Any state (e.g., text typed into an `<input>` is lost.
2.  **No Transition:** The switch is abrupt. There’s no animation between directions.
3.  **DX/Boilerplate:** Requires maintaining two separate wrapper components.

## 💡 The Solution
Since `vaul` is built on top of Radix/Base UI Dialog primitives, we can handle the "Desktop Modal" state directly within `vaul` by adding a `center` direction.

By unifying the CSS `transform` logic for all directions, we can now simply change the `direction` prop dynamically:

```tsx
const isMobile = useIsMobile()

return (
  <Drawer.Root direction={isMobile ? "bottom" : "center"}>
    <Drawer.Content>
       {/* State is preserved during resize! */}
       <ProfileForm />
    </Drawer.Content>
  </Drawer.Root>
)
```

## 🛠️ Changes

### 1. Unified Coordinate System
Previously, different directions used different CSS properties (`top`, `bottom`, `left`, `right`) which made CSS transitions between them impossible.
I refactored `style.css` so that all directions (including the new `center`) use a unified `transform: translate3d(...)` approach relative to consistent offsets (e.g., `50%`).

### 2. `center` Direction
Added support for `direction="center"`. This mimics a standard modal dialog behavior but keeps the `vaul` context alive.

### 3. Morphing vs. Entry Animation
Added a `data-vaul-drawer-morphing` attribute.
- **Initial Open:** Plays the standard slide-in animation.
- **Resize/Prop Change:** Disables the keyframe animation and uses a fluid CSS transition to "morph" the drawer to its new position (e.g., sliding from bottom to center).

### 4. Drag Logic Update
Updated the JS drag calculations (`onDrag`, `resetDrawer`) to respect the new CSS offsets, ensuring dragging works correctly.

## Demo
I have added an responsive example to the example page.


